### PR TITLE
Saturn V patches for realistic mode

### DIFF
--- a/BR-Apollo/S-IC/Rocketdyne F-1.prefab
+++ b/BR-Apollo/S-IC/Rocketdyne F-1.prefab
@@ -8537,7 +8537,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   thrust:
     variables: {fileID: 4125211162013701134}
-    input: 1150
+    input: 690
   thrustNormal:
     variables: {fileID: 4125211162013701134}
     x:
@@ -8577,7 +8577,7 @@ MonoBehaviour:
     referenceToVariables: {fileID: 4125211162013701134}
     localValue: 0
   heatHolder: {fileID: 6047835000289864994}
-  oldMass: 14.0833
+  oldMass: 8.45
 --- !u!114 &1259208727223967406
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/BR-Apollo/S-IC/Rocketdyne F-1.prefab
+++ b/BR-Apollo/S-IC/Rocketdyne F-1.prefab
@@ -8537,7 +8537,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   thrust:
     variables: {fileID: 4125211162013701134}
-    input: 680
+    input: 1150
   thrustNormal:
     variables: {fileID: 4125211162013701134}
     x:
@@ -8548,7 +8548,7 @@ MonoBehaviour:
       input: 1
   ISP:
     variables: {fileID: 4125211162013701134}
-    input: 210
+    input: 265.4
   thrustPosition:
     variables: {fileID: 4125211162013701134}
     x:
@@ -8577,7 +8577,7 @@ MonoBehaviour:
     referenceToVariables: {fileID: 4125211162013701134}
     localValue: 0
   heatHolder: {fileID: 6047835000289864994}
-  oldMass: 12
+  oldMass: 8.45
 --- !u!114 &1259208727223967406
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/BR-Apollo/S-IC/Rocketdyne F-1.prefab
+++ b/BR-Apollo/S-IC/Rocketdyne F-1.prefab
@@ -8577,7 +8577,7 @@ MonoBehaviour:
     referenceToVariables: {fileID: 4125211162013701134}
     localValue: 0
   heatHolder: {fileID: 6047835000289864994}
-  oldMass: 8.45
+  oldMass: 14.0833
 --- !u!114 &1259208727223967406
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/BR-Apollo/S-IC/S-IC Thrust Structure.prefab
+++ b/BR-Apollo/S-IC/S-IC Thrust Structure.prefab
@@ -4330,7 +4330,7 @@ MonoBehaviour:
       input: 0
     y:
       variables: {fileID: 6025496177165280511}
-      input: -20
+      input: -79.7415
   thrustPosition:
     variables: {fileID: 6025496177165280511}
     x:
@@ -4341,7 +4341,7 @@ MonoBehaviour:
       input: 0
   wetMass:
     variables: {fileID: 6025496177165280511}
-    input: 1
+    input: 0.75944
   dryMassPercent:
     variables: {fileID: 6025496177165280511}
     input: 0.1
@@ -5502,7 +5502,7 @@ MonoBehaviour:
       input: 0
     y:
       variables: {fileID: 6025496177165280511}
-      input: -20
+      input: -79.7415
   thrustPosition:
     variables: {fileID: 6025496177165280511}
     x:
@@ -5513,7 +5513,7 @@ MonoBehaviour:
       input: 0
   wetMass:
     variables: {fileID: 6025496177165280511}
-    input: 1
+    input: 0.75944
   dryMassPercent:
     variables: {fileID: 6025496177165280511}
     input: 0.1
@@ -6645,7 +6645,7 @@ MonoBehaviour:
       input: 0
     y:
       variables: {fileID: 6025496177165280511}
-      input: -20
+      input: --79.7415
   thrustPosition:
     variables: {fileID: 6025496177165280511}
     x:
@@ -6656,7 +6656,7 @@ MonoBehaviour:
       input: 0
   wetMass:
     variables: {fileID: 6025496177165280511}
-    input: 1
+    input: 0.75944
   dryMassPercent:
     variables: {fileID: 6025496177165280511}
     input: 0.1
@@ -7645,7 +7645,7 @@ MonoBehaviour:
       input: 0
     y:
       variables: {fileID: 6025496177165280511}
-      input: -20
+      input: -79.7415
   thrustPosition:
     variables: {fileID: 6025496177165280511}
     x:
@@ -7656,7 +7656,7 @@ MonoBehaviour:
       input: 0
   wetMass:
     variables: {fileID: 6025496177165280511}
-    input: 1
+    input: 0.75944
   dryMassPercent:
     variables: {fileID: 6025496177165280511}
     input: 0.1

--- a/BR-Apollo/S-II/Interstage Ullage Motor.prefab
+++ b/BR-Apollo/S-II/Interstage Ullage Motor.prefab
@@ -949,7 +949,7 @@ MonoBehaviour:
       input: 0
     y:
       variables: {fileID: 6025496177165280511}
-      input: 50
+      input: 9.52544
   thrustPosition:
     variables: {fileID: 6025496177165280511}
     x:

--- a/BR-Apollo/S-IVB/IB S-IVB Aft Interstage.prefab
+++ b/BR-Apollo/S-IVB/IB S-IVB Aft Interstage.prefab
@@ -1328,7 +1328,7 @@ MonoBehaviour:
       input: 0
     y:
       variables: {fileID: 128775577033961292}
-      input: -20
+      input: -34.0194
   thrustPosition:
     variables: {fileID: 128775577033961292}
     x:
@@ -1920,7 +1920,7 @@ MonoBehaviour:
       input: 0
     y:
       variables: {fileID: 128775577033961292}
-      input: -20
+      input: -34.0194
   thrustPosition:
     variables: {fileID: 128775577033961292}
     x:

--- a/BR-Apollo/S-IVB/Instrument Unit.prefab
+++ b/BR-Apollo/S-IVB/Instrument Unit.prefab
@@ -8589,7 +8589,7 @@ MonoBehaviour:
     plainText: 1
   mass:
     variables: {fileID: 5371138025553930724}
-    input: 2
+    input: 2.
   centerOfMass:
     variables: {fileID: 5371138025553930724}
     x:

--- a/BR-Apollo/S-IVB/Rocketdyne J-2.prefab
+++ b/BR-Apollo/S-IVB/Rocketdyne J-2.prefab
@@ -10910,7 +10910,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   thrust:
     variables: {fileID: 6287457034714228805}
-    input: 230
+    input: 104.3
   thrustNormal:
     variables: {fileID: 6287457034714228805}
     x:
@@ -10921,7 +10921,7 @@ MonoBehaviour:
       input: 1
   ISP:
     variables: {fileID: 6287457034714228805}
-    input: 130
+    input: 425
   thrustPosition:
     variables: {fileID: 6287457034714228805}
     x:
@@ -10950,7 +10950,7 @@ MonoBehaviour:
     referenceToVariables: {fileID: 6287457034714228805}
     localValue: 0
   heatHolder: {fileID: 3092264008158961400}
-  oldMass: 6
+  oldMass: 1.59
 --- !u!114 &9153463731116581605
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/BR-Apollo/S-IVB/S-IVB Ullage Motor.prefab
+++ b/BR-Apollo/S-IVB/S-IVB Ullage Motor.prefab
@@ -175,7 +175,7 @@ MonoBehaviour:
       input: 0
     y:
       variables: {fileID: 3852902279926224910}
-      input: 30
+      input: 1.54221
   thrustPosition:
     variables: {fileID: 3852902279926224910}
     x:

--- a/README.md
+++ b/README.md
@@ -1,101 +1,17 @@
+Patched the Saturn V parts for real-world values: hopefully works on realistic mode.
 
-   __ )    _ \             \                   |  |        
-   __ \   |   |           _ \    __ \    _ \   |  |   _ \  
-   |   |  __ <   ____|   ___ \   |   |  (   |  |  |  (   | 
-  ____/  _| \_\        _/    _\   __/  \___/  _| _| \___/  v1.2
-                                _|                         
-Made on Earth, by Brioche
-If ASCII art is broken, download file & open in notepad x
---------------------------------------------------------------------
-██████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-█████████████████░░░░░░░░░░░░░░░░░█████████████████░░░░░░░░░░░░░░░░░
+IMPORTANT:
+If an engine is used 5 times IRL but 3 times in SFS because it is 2D, I DID NOT ACCOUNT FOR THAT.
 
-▛▚ Thanks for downloading! ▛▚
+I DO NOT KNOW HOW TO USE THE DENSITY PARAMETER, so all of them containing it HAVE BEEN SKIPPED.
+Here are the ones that have been skipped and the desired values:
 
-If you're reading this, you're one out of a rough personal estimate of 3 and a half people that will open this file.
-This is BR-Apollo, my passion project for over two years now. This started as a (very) short-lived custom texture pack attempt, but has grown into something bigger than I could ever have imagined.
+BR-Apollo/S-II/S-II Aft Interstage.prefab, target mass is 5.2896 t.
 
-▛▚ Installation instructions ▛▚
+BR-Apollo/S-II/S-II Fuel Tank.prefab, BR-Apollo/S-II/S-II Engine Mount.prefab. The Density and dryMassPercent values should be tweaked, so that the S-II, including five (should be three but 1.) J-2 engines but excluding the S-IC/S-II aft interstage, reaches a Wet mass of 484.9423 t, a Dry mass of 38.3738 t, and a propellant mass of 446.5685 t.
 
-Download the file with the .pack extension from the BR-Apollo Github releases tab. Open your SFS game, navigate to the Modloader menu, click "Open Mods Folder." Once your file explorer opens, go through Custom Assets -> Parts, and drag in the .pack file. Relaunch the game, and BR-Apollo will be installed.
+BR-Apollo/S-IVB/S-IVB Aft Interstage.prefab, the target mass of the complete interstage is 3.6655 t.
 
+BR-Apollo/S-IVB/S-IVB Fuel Tank Series 500.prefab, BR-Apollo/S-IVB/S-IVB Engine Mount Series 500.prefab. The desired masses of the assembled Saturn V S-IVB, including the J-2 but excluding the aft interstage and instrument unit, are Wet mass: 117.6334 t, Dry mass: 11.4759 t, and Propellant mass: 106.1575 t
 
-▛▚ USAGE GUIDELINES ▛▚
-
-	Posting BR-Apollo online:
-
-		I Highly doubt anybody will end up reading this, much less follow it, but here's what I would like to be included if you decide to make a post featuring my mod.
-
-		Youtube:
-		Please add link to my channel, the jmnet forum post, and the github repo. 
-		Adding a link to the discord server would also be pretty cool, but that's a lot of links, you don't have to do that.
-		Also, please mention my channel so I get a notification, I would love to watch!
-
-		Instagram/Reddit:
-		In the title/somewhere visible, put BR-Apollo mod by @briocheandthejets or u/BriocheRockets so I get to see the post!
-
-		Discord:
-		Just put my username and the name of the mod :)
-
-		That being said, I don't really care too much what you put. If I see it, I'm just happy someone enjoyed my work.
-
-	Creating an addon pack for BR-Apollo:
-
-		Seeing as Eyes Turned Skyward and For All Mankind material will never be added to BR-Apollo, it's possible someone would want to create a ETS/FAM addon mod.
-		If that person happens to be you, by all means, go ahead. Source code & prefabs are all open-source, so feel free to download them and take 'em apart.
-		If you publish an addon mod, please follow this naming convention: "<mod name> - Addon for BR-Apollo"
-
-
-	Stuff I just don't want to see done with my mod:
-
-		Recreating tragedies, e.g. Apollo 1 pad fire. Just don't do this, please.
-		The stack is recreatable with the Block 1 CSM parts and the Saturn IB, and is even showcased in the trailer for 1.1.
-		This however, is, and should ONLY be used, to honor the mission that should have flown and NOT to recreate what eventually transpired at Pad 34.
-
-	Do not use the source code whenever I push backups to download unreleased parts and release them. Not cool.
-
-▛▚ Dorg ▛▚
-	dorg.png is a picture of my dog that takes up exactly 32 kilobytes, the exact amount of data it would take to max out Saturn V instrument unit. Do with that what you will.
-
-▛▚ Credits ▛▚
-	Raw LM mylar texture courtesy of unnamed_shadow1
-	LES custom behavior courtesy of dani0105 https://github.com/105-Code/basp-modules
-
-▒
-▒      /\
-▒      ▒▒
-▒
-▒     |  |
-▒     ████
-▒     |
-▒     |
-▒     ░░░░             /\
-▒    /  ██\            ▒▒
-▒    ░░░░░░                            /\
-▒    :   :            |  |             ▒▒
-▒    :   :            ████             
-▒                     |               /  \
-▒    ██████           |                   
-▒    █░░██░           ████            ████
-▒    █░░██░           █ █             █ █ 
-▒                     ====            ====
-▒    =  "=            █ █░            █ █░
-▒                     █ █░            █ █░
-▒    ░░░░░░           █ █░            █ █░
-▒    █  ██            █ █░            █ █░
-▒    █  ██          ,<█ █░>,       .-=█ █░=-.
-▒   /█░░██░\       |>|_█_█|<|      |_|_█_█|_|
-▒    /\/\/\           ^^^^            ^^^^
-▒
-▒
-▒
-▒████  ████     ████  ████  █████ ██    ██    █████
-▒██  █ ██  █    ██  █ ██  █ ██  █ ██    ██    ██  █
-▒████  ████  ██ █████ █████ ██  █ ██    ██    ██  █
-▒██  █ ██  █    ██  █ ██    ██  █ ██    ██    ██  █
-▒█████ ██  █    ██  █ ██    █████ █████ █████ █████
-▒
-▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
-
-
-made with love by brioche. thank you everyone
+If you find any issues, please contact me. If you can and have the patience though, you could try fixing them.


### PR DESCRIPTION
Patched the Saturn V parts for real-world values: hopefully works on realistic mode.
### **IMPORTANT:**
1. If an engine is used 5 times IRL but 3 times in SFS because it is 2D, **I DID NOT ACCOUNT FOR THAT.**
2. **I DO NOT KNOW HOW TO USE THE DENSITY PARAMETER**, so all of them containing it **HAVE BEEN SKIPPED.**
Here are the ones that have been skipped and the desired values:

1. BR-Apollo/S-II/S-II Aft Interstage.prefab, target mass is 5.2896 t.

2. BR-Apollo/S-II/S-II Fuel Tank.prefab, BR-Apollo/S-II/S-II Engine Mount.prefab. The Density and dryMassPercent values should be tweaked, so that the S-II, including five (should be three but 1.) J-2 engines but excluding the S-IC/S-II aft interstage, reaches a Wet mass of 484.9423 t, a Dry mass of 38.3738 t, and a propellant mass of 446.5685 t.

3. BR-Apollo/S-IVB/S-IVB Aft Interstage.prefab, the target mass of the complete interstage is 3.6655 t.

4. BR-Apollo/S-IVB/S-IVB Fuel Tank Series 500.prefab, BR-Apollo/S-IVB/S-IVB Engine Mount Series 500.prefab. The desired masses of the assembled Saturn V S-IVB, including the J-2 but excluding the aft interstage and instrument unit, are Wet mass: 117.6334 t, Dry mass: 11.4759 t, and Propellant mass: 106.1575 t

If you find any issues, please contact me. If you can and have the patience though, you could try fixing them.